### PR TITLE
Add preload link for Tours hero image

### DIFF
--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -10,6 +10,7 @@ interface SEOHeadProps {
   schema?: string; // изменили на строку!
   canonical?: string;
   noIndex?: boolean;
+  preloadImages?: string[];
 }
 
 function absoluteUrl(path: string) {
@@ -37,6 +38,7 @@ const SEOHead: React.FC<SEOHeadProps> = ({
   schema,
   canonical,
   noIndex,
+  preloadImages,
 }) => {
   const location = useLocation();
   const { language } = useLanguage();
@@ -77,6 +79,20 @@ const SEOHead: React.FC<SEOHeadProps> = ({
       document.head.appendChild(link);
     });
   }, []);
+
+  // Preload images if provided
+  React.useEffect(() => {
+    if (!preloadImages || typeof document === "undefined") return;
+    preloadImages.forEach(src => {
+      if (!document.head.querySelector(`link[rel='preload'][href='${src}']`)) {
+        const link = document.createElement("link");
+        link.rel = "preload";
+        link.setAttribute("as", "image");
+        link.href = src;
+        document.head.appendChild(link);
+      }
+    });
+  }, [preloadImages]);
 
   // Canonical — убираем параметры page/sort/utm
   React.useEffect(() => {

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -14,9 +14,10 @@ interface LayoutProps {
   colorScheme?: "tourist" | "relocator" | "default";
   title?: string;
   description?: string;
+  preloadImages?: string[];
 }
 
-const Layout = ({ children, colorScheme = "default", title, description }: LayoutProps) => {
+const Layout = ({ children, colorScheme = "default", title, description, preloadImages }: LayoutProps) => {
   const { language, setLanguage, t } = useLanguage();
   
   // Update page title and description for SEO
@@ -164,6 +165,7 @@ const Layout = ({ children, colorScheme = "default", title, description }: Layou
         description={description || "Travel in Calabria, Italy: Tours, guides, relocation support."}
         canonical={canonicalUrl}
         schema={schema}
+        preloadImages={preloadImages}
       />
       {/* Header/Navigation */}
       <header className={`bg-white border-b ${headerAccentColor} sticky top-0 z-10`} role="banner">

--- a/src/pages/Tours.tsx
+++ b/src/pages/Tours.tsx
@@ -35,10 +35,11 @@ const Tours = () => {
   const content = tourContent[language];
 
   return (
-    <Layout 
+    <Layout
       colorScheme="tourist"
       title={`${content.title} - Calabria Explorer`}
       description={content.intro}
+      preloadImages={["/lovable-uploads/6d3b6b08-c072-43d0-9bb7-4a32452ce1e1.png"]}
     >
       {/* Hero Section */}
       <section className="relative bg-gradient-to-br from-[#0077B6] via-[#00A9E6] to-[#0077B6] text-white py-16 overflow-hidden">


### PR DESCRIPTION
## Summary
- support preloading images via `preloadImages` prop
- pass the hero image to `Layout` in the Tours page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685807c5d4f0832c88c69f235183bc23