### PR TITLE
Add extra tour SEO data

### DIFF
--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -11,6 +11,10 @@ interface SEOHeadProps {
   canonical?: string;
   noIndex?: boolean;
   preloadImages?: string[];
+  price?: number;
+  offerUrl?: string;
+  startLocation?: string;
+  startDate?: string;
 }
 
 function absoluteUrl(path: string) {
@@ -39,6 +43,10 @@ const SEOHead: React.FC<SEOHeadProps> = ({
   canonical,
   noIndex,
   preloadImages,
+  price,
+  offerUrl,
+  startLocation,
+  startDate,
 }) => {
   const location = useLocation();
   const { language } = useLanguage();
@@ -128,9 +136,9 @@ const SEOHead: React.FC<SEOHeadProps> = ({
           "inLanguage": language,
         });
       } else if (location.pathname.startsWith("/tours/")) {
-        pageSchema = JSON.stringify({
+        const trip: any = {
           "@context": "https://schema.org",
-          "@type": "TouristTrip",
+          "@type": startDate ? "Event" : "TouristTrip",
           "name": title,
           "description": description,
           "image": absoluteUrl(image || "/favicon.ico"),
@@ -138,9 +146,17 @@ const SEOHead: React.FC<SEOHeadProps> = ({
           "offers": {
             "@type": "Offer",
             "priceCurrency": "EUR",
-            "availability": "https://schema.org/InStock"
-          }
-        });
+            "availability": "https://schema.org/InStock",
+            ...(price ? { price } : {}),
+            ...(offerUrl ? { url: offerUrl } : {})
+          },
+        };
+        if (startDate) trip.startDate = startDate;
+        if (startLocation) {
+          const place = { "@type": "Place", name: startLocation };
+          if (startDate) trip.location = place; else trip.startLocation = place;
+        }
+        pageSchema = JSON.stringify(trip);
       } else {
         // BreadcrumbList
         const pathChunks = location.pathname.split("/").filter(Boolean);
@@ -182,7 +198,7 @@ const SEOHead: React.FC<SEOHeadProps> = ({
       script.innerHTML = pageSchema;
       document.head.appendChild(script);
     }
-  }, [schema, location.pathname, title, description, image, language]);
+  }, [schema, location.pathname, title, description, image, language, price, offerUrl, startLocation, startDate]);
 
   // Meta теги (SPA-навигация)
   React.useEffect(() => {

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -15,9 +15,23 @@ interface LayoutProps {
   title?: string;
   description?: string;
   preloadImages?: string[];
+  price?: number;
+  offerUrl?: string;
+  startLocation?: string;
+  startDate?: string;
 }
 
-const Layout = ({ children, colorScheme = "default", title, description, preloadImages }: LayoutProps) => {
+const Layout = ({
+  children,
+  colorScheme = "default",
+  title,
+  description,
+  preloadImages,
+  price,
+  offerUrl,
+  startLocation,
+  startDate,
+}: LayoutProps) => {
   const { language, setLanguage, t } = useLanguage();
   
   // Update page title and description for SEO
@@ -124,9 +138,9 @@ const Layout = ({ children, colorScheme = "default", title, description, preload
       });
     }
     if (isTour) {
-      return JSON.stringify({
+      const trip: any = {
         "@context": "https://schema.org",
-        "@type": "TouristTrip",
+        "@type": startDate ? "Event" : "TouristTrip",
         "name": title,
         "description": description,
         "image": window.location.origin + "/favicon.ico",
@@ -134,9 +148,17 @@ const Layout = ({ children, colorScheme = "default", title, description, preload
         "offers": {
           "@type": "Offer",
           "priceCurrency": "EUR",
-          "availability": "https://schema.org/InStock"
+          "availability": "https://schema.org/InStock",
+          ...(price ? { price } : {}),
+          ...(offerUrl ? { url: offerUrl } : {})
         }
-      });
+      };
+      if (startDate) trip.startDate = startDate;
+      if (startLocation) {
+        const place = { "@type": "Place", name: startLocation };
+        if (startDate) trip.location = place; else trip.startLocation = place;
+      }
+      return JSON.stringify(trip);
     }
     // BreadcrumbList для остального
     const pathChunks = window.location.pathname
@@ -156,7 +178,7 @@ const Layout = ({ children, colorScheme = "default", title, description, preload
       });
     }
     return undefined;
-  }, [title, description, language, isBlogPost, isTour ]);
+  }, [title, description, language, isBlogPost, isTour, price, offerUrl, startLocation, startDate]);
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -166,6 +188,10 @@ const Layout = ({ children, colorScheme = "default", title, description, preload
         canonical={canonicalUrl}
         schema={schema}
         preloadImages={preloadImages}
+        price={price}
+        offerUrl={offerUrl}
+        startLocation={startLocation}
+        startDate={startDate}
       />
       {/* Header/Navigation */}
       <header className={`bg-white border-b ${headerAccentColor} sticky top-0 z-10`} role="banner">

--- a/src/pages/Melissa.tsx
+++ b/src/pages/Melissa.tsx
@@ -88,10 +88,12 @@ const Melissa = () => {
   const content = tourContent[language];
 
   return (
-    <Layout 
+    <Layout
       colorScheme="tourist"
       title={`${content.title} - Calabria Explorer`}
       description={content.intro}
+      price={45}
+      offerUrl="https://wa.me/393446935576"
     >
       {/* Hero Section */}
       <section className="relative bg-gradient-to-r from-[#E2725B] to-[#D4511E] text-white py-16">

--- a/src/pages/Pallagorio.tsx
+++ b/src/pages/Pallagorio.tsx
@@ -95,10 +95,12 @@ const Pallagorio = () => {
   const content = tourContent[language];
 
   return (
-    <Layout 
+    <Layout
       colorScheme="tourist"
       title={`${content.title} - Calabria Explorer`}
       description={content.intro}
+      price={85}
+      offerUrl="https://wa.me/393446935576"
     >
       {/* Hero Section */}
       <section className="relative bg-gradient-to-r from-[#E2725B] to-[#D4511E] text-white py-16">

--- a/src/pages/SenatoreVini.tsx
+++ b/src/pages/SenatoreVini.tsx
@@ -90,10 +90,13 @@ const SenatoreVini = () => {
   };
 
   return (
-    <Layout 
+    <Layout
       colorScheme="tourist"
       title={`${content.title} - Calabria Explorer`}
       description={content.intro}
+      price={55}
+      offerUrl="https://wa.me/393446935576"
+      startLocation={content.details.meetingPoint}
     >
       {/* Hero Section */}
       <section className="relative bg-gradient-to-r from-[#0077B6] to-[#00A9E6] text-white py-16">

--- a/src/pages/Umbriatico.tsx
+++ b/src/pages/Umbriatico.tsx
@@ -77,10 +77,13 @@ const Umbriatico = () => {
   };
 
   return (
-    <Layout 
+    <Layout
       colorScheme="tourist"
       title={`${content.title} - Calabria Explorer`}
       description={content.description}
+      price={50}
+      offerUrl="https://wa.me/393446935576"
+      startLocation={content.meetingPoint}
     >
       {/* Hero Section */}
       <section className="relative">


### PR DESCRIPTION
## Summary
- extend `SEOHead` schema with price, url and location info
- add tour metadata through `Layout`
- supply price and booking info for tour pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68580afcbc48832ca3f476201cb645d8