### PR TITLE
Add author section and update blog content

### DIFF
--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -97,7 +97,7 @@ const SEOHead: React.FC<SEOHeadProps> = ({
   // Canonical — убираем параметры page/sort/utm
   React.useEffect(() => {
     let canonicalTag = document.querySelector("link[rel='canonical']");
-    let canonicalHref = url.replace(/\?(page|sort|utm_.*?)=[^&]+(&|$)/g, "");
+    const canonicalHref = url.replace(/\?(page|sort|utm_.*?)=[^&]+(&|$)/g, "");
     if (!canonicalTag) {
       canonicalTag = document.createElement("link");
       (canonicalTag as HTMLLinkElement).rel = "canonical";
@@ -213,7 +213,7 @@ const SEOHead: React.FC<SEOHeadProps> = ({
     const head = document.head;
 
     const setMetaTag = (name: string, content: string, propType: "name" | "property" = "property") => {
-      let selector = propType === "property" ? `meta[property='${name}']` : `meta[name='${name}']`;
+      const selector = propType === "property" ? `meta[property='${name}']` : `meta[name='${name}']`;
       let tag = head.querySelector(selector);
       if (!tag) {
         tag = document.createElement("meta");
@@ -249,7 +249,7 @@ const SEOHead: React.FC<SEOHeadProps> = ({
     setMetaTag("twitter:site", "@calabriaexplorer", "name");
 
     // theme-color
-    let theme = document.querySelector("meta[name='theme-color']") as HTMLMetaElement;
+    const theme = document.querySelector("meta[name='theme-color']") as HTMLMetaElement;
     if (!theme) {
       const meta = document.createElement("meta");
       meta.name = "theme-color";

--- a/src/components/blog/AboutAuthor.tsx
+++ b/src/components/blog/AboutAuthor.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const AboutAuthor: React.FC = () => {
+  const { t } = useLanguage();
+  return (
+    <section className="about-author mt-8 bg-gray-50 p-4 rounded-lg border">
+      <h2 className="text-xl font-bold mb-2">{t("aboutAuthor.title")}</h2>
+      <p>{t("aboutAuthor.text")}</p>
+    </section>
+  );
+};
+
+export default AboutAuthor;

--- a/src/components/blog/DogLifeArticleEn.tsx
+++ b/src/components/blog/DogLifeArticleEn.tsx
@@ -3,19 +3,19 @@ import React from "react";
 
 const DogLifeArticleEn = () => (
   <div className="prose max-w-full sm:mx-auto px-2 py-2">
-    <h2 className="text-2xl font-bold text-[#2196F3] mb-2">🐶 Dog Owner Life in Italy: Balconies, Barkfests &amp; Siestas</h2>
+    <h2 className="text-2xl font-bold text-[#2196F3] mb-2">Dog Owner Life in Italy: Balconies, Barkfests &amp; Siestas</h2>
     <h3 className="text-lg font-semibold text-[#2579c5] mb-2">Where leashes are sacred and vets vanish after lunch</h3>
     <p>
       <strong>Dogs on balcony in Italy</strong><br />
-      Think dog ownership is just walks and feeding? In Italy, it's a whole comedy show. While owners are at work, their four-legged friends hold "balcony debates" across neighborhoods. Even our usually silent Alabai (who acts like a mafia boss) suddenly barks back at neighbor's dachshunds and Pomeranians. Apparently, boredom is the best motivator for canine gossip. 🐾
+      Think dog ownership is just walks and feeding? In Italy, it's a whole comedy show. While owners are at work, their four-legged friends hold "balcony debates" across neighborhoods. Even our usually silent Alabai suddenly barks back at neighbor's dachshunds and Pomeranians. Apparently boredom is the best motivator for canine gossip.
     </p>
     <h4 className="font-bold mt-4 text-[#2982c6]">🎯 The Sacred Leash Law</h4>
     <p>
-      Fun fact: All dogs here — from tiny Yorkies to giant Great Danes — walk on leashes. Not because Italians are law-abiding, but because it prevents "accidental" showdowns. Considering you might bump into a real 'Ndrangheta boss any minute, everyone avoids creating tricky dog situations. A leash is like an invisible fence saving your nerves, clothes from fur, and possibly your health. 😅
+      Fun fact: All dogs here — from tiny Yorkies to giant Great Danes — walk on leashes. Not because Italians are law-abiding, but because it prevents "accidental" showdowns. A leash is like an invisible fence saving your nerves and clothes from fur. See official rules on the <a href="https://www.salute.gov.it/portale/home.html" target="_blank" rel="noopener">Italian Ministry of Health</a> website.
     </p>
     <h4 className="font-bold mt-4 text-[#2982c6]">🍖 Dog Food: Cheaper Than Pasta?</h4>
     <p>
-      About food: Good professional dog food costs around €2 per kilo. A 20kg bag is about €40. Not cheap, but not astronomical. Just don't confuse it with supermarket brands — unless you want your dog to give you the "I hate you all" look. 🐶💔
+      About food: Good professional dog food costs around €2 per kilo. A 20kg bag is about €40. Just don't confuse it with supermarket brands — unless you want your dog to give you the "I hate you all" look.
     </p>
     <div className="my-3 px-3 py-3 rounded-lg bg-blue-50 border border-blue-100 text-blue-900 shadow-sm">
       <span className="font-bold">⚠️ Pro tip:</span> Look for "<strong>super premium</strong>" labels — Italian vets say it's like parmesan for dogs.

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -100,7 +100,7 @@ const Layout = ({ children, colorScheme = "default", title, description, image, 
   };
 
   // Определяем canonical
-  let canonicalUrl = typeof window !== "undefined" 
+  const canonicalUrl = typeof window !== "undefined" 
     ? window.location.origin + window.location.pathname 
     : undefined;
 

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -17,7 +17,7 @@ const translations = {
     "tours": "Tours",
     
     // Hero
-    "hero.title": "Calabria: Where La Dolce Vita Meets Affordability",
+    "hero.title": "Calabria Explorer – real stories and local tours",
     "hero.subtitle": "Discover Italy's hidden gem - pristine beaches, rich culture, and authentic living",
     
     // Audience Selection
@@ -74,6 +74,8 @@ const translations = {
     "footer.relocation": "Relocation",
     "footer.connect": "Connect With Us",
     "footer.copyright": "All rights reserved.",
+    "aboutAuthor.title": "About the Author",
+    "aboutAuthor.text": "Maria has lived in Calabria for over 10 years. She is a licensed guide offering personal tours."
   },
   ru: {
     // Home
@@ -83,7 +85,7 @@ const translations = {
     "tours": "Экскурсии",
     
     // Hero
-    "hero.title": "Калабрия: Где La Dolce Vita Встречается с Доступностью",
+    "hero.title": "Calabria Explorer – реальные истории и авторские туры",
     "hero.subtitle": "Откройте для себя скрытую жемчужину Италии - нетронутые пляжи, богатую культуру и аутентичную жизнь",
     
     // Audience Selection
@@ -140,6 +142,8 @@ const translations = {
     "footer.relocation": "Переезд",
     "footer.connect": "Свяжитесь с Нами",
     "footer.copyright": "Все права защищены.",
+    "aboutAuthor.title": "Об авторе",
+    "aboutAuthor.text": "Мария живёт в Калабрии более 10 лет. Она лицензированный гид и проводит авторские туры."
   }
 };
 

--- a/src/pages/DogLifePost.tsx
+++ b/src/pages/DogLifePost.tsx
@@ -4,6 +4,7 @@ import { useLanguage } from "@/contexts/LanguageContext";
 import Layout from "@/components/layout/Layout";
 import DogLifeArticleRu from "@/components/blog/DogLifeArticleRu";
 import DogLifeArticleEn from "@/components/blog/DogLifeArticleEn";
+import AboutAuthor from "@/components/blog/AboutAuthor";
 import Gallery from "@/components/ui/Gallery";
 
 const images = [
@@ -48,6 +49,7 @@ const DogLifePost = () => {
         <p className="mb-4 text-gray-600 text-center">{dogBlogDescriptions[language]}</p>
         <Gallery images={images} />
         {language === "ru" ? <DogLifeArticleRu /> : <DogLifeArticleEn />}
+        <AboutAuthor />
       </article>
     </Layout>
   );

--- a/src/pages/LeCastellaPost.tsx
+++ b/src/pages/LeCastellaPost.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import Gallery from "@/components/ui/Gallery";
 import LeCastellaArticleRu from "@/components/blog/LeCastellaArticleRu";
 import LeCastellaArticleEn from "@/components/blog/LeCastellaArticleEn";
+import AboutAuthor from "@/components/blog/AboutAuthor";
 
 const images = [
   { src: "/lovable-uploads/5017e784-dec8-4499-8f82-348763675b74.png", alt: "Le Castella viewed from the sea on a sunny day" },
@@ -201,6 +202,7 @@ const LeCastellaPost: React.FC = () => {
               mariamarinaciro@gmail.com
             </a>
           </div>
+          <AboutAuthor />
         </div>
       </section>
     </Layout>


### PR DESCRIPTION
## Summary
- add `AboutAuthor` component
- display author info on Le Castella and Dog Life posts
- update translations with author strings and new hero title
- tone down Dog Life article style and add reference link
- minor lint-driven fixes

## Testing
- `npm run lint -- --fix` *(fails: unexpected any and other errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870f67a93c0832c9023729fdcb18508