### PR TITLE
Add author component to two blog posts

### DIFF
--- a/src/pages/SingleBlogPost.tsx
+++ b/src/pages/SingleBlogPost.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import Gallery from "@/components/ui/Gallery";
 import RuCalabriaArticle from "@/components/blog/RuCalabriaArticle";
 import EnCalabriaArticle from "@/components/blog/EnCalabriaArticle";
+import AboutAuthor from "@/components/blog/AboutAuthor";
 
 const articleImages = [
   {
@@ -231,6 +232,7 @@ const SingleBlogPost: React.FC = () => {
               mariamarinaciro@gmail.com
             </a>
           </div>
+          <AboutAuthor />
         </div>
       </section>
     </Layout>

--- a/src/pages/WaterOrSwampJuicePost.tsx
+++ b/src/pages/WaterOrSwampJuicePost.tsx
@@ -3,6 +3,7 @@ import { useLanguage } from "@/contexts/LanguageContext";
 import Layout from "@/components/layout/Layout";
 import SEOHead from "@/components/SEOHead";
 import Gallery from "@/components/ui/Gallery";
+import AboutAuthor from "@/components/blog/AboutAuthor";
 const articleImages = [{
   src: "/lovable-uploads/e23f8b3b-f1dc-4a17-a7fe-cd2896aaea08.png",
   alt_ru: "Кристально чистая вода и галька на пляже Калабрии",
@@ -174,6 +175,7 @@ const WaterOrSwampJuicePost: React.FC = () => {
             {language === "ru" ? "← Назад к блогу" : "← Back to blog"}
           </button>
           {article[language]}
+          <AboutAuthor />
         </div>
       </section>
     </Layout>;


### PR DESCRIPTION
## Summary
- import and display the AboutAuthor section on the "Water or Swamp Juice" post
- show the AboutAuthor section on the "Hidden Gems of Italian Wine" post

## Testing
- `npm run lint` *(fails: cannot pass existing ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687100a017d8832ca5e9baa940edc25d