### PR TITLE
Add Yandex Metrika counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,14 +60,14 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
 
     <!-- Yandex.Metrika counter -->
-    <script type="text/javascript" >
+    <script type="text/javascript">
        (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
        m[i].l=1*new Date();
        for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
        k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
        (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
 
-       ym(102382750, "init", {
+       ym(103297596, "init", {
             clickmap:true,
             trackLinks:true,
             accurateTrackBounce:true,
@@ -149,7 +149,11 @@
   </head>
 
   <body>
-    <noscript><div><img src="https://mc.yandex.ru/watch/102382750" style="position:absolute; left:-9999px;" alt="Yandex Metrika tracking pixel" /></div></noscript>
+    <noscript>
+      <div>
+        <img src="https://mc.yandex.ru/watch/103297596" style="position:absolute; left:-9999px;" alt="" />
+      </div>
+    </noscript>
     <div id="root"></div>
     <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
     <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>

--- a/index.html
+++ b/index.html
@@ -74,8 +74,7 @@
             webvisor:true
        });
     </script>
-    <!-- /Yandex.Metrika counter -->
-
+    
     <!-- Structured Data for Tourism -->
     <script type="application/ld+json">
     {
@@ -154,6 +153,7 @@
         <img src="https://mc.yandex.ru/watch/103297596" style="position:absolute; left:-9999px;" alt="" />
       </div>
     </noscript>
+    <!-- /Yandex.Metrika counter -->
     <div id="root"></div>
     <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
     <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>


### PR DESCRIPTION
## Summary
- integrate Yandex.Metrika with counter ID 103297596 in `index.html`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710e5ace50832ca7676f38be8f9fb6