### PR TITLE
Remove extra footer links

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -298,22 +298,9 @@ const Layout = ({ children, colorScheme = "default", title, description, image, 
                     <Link to="#relocation" className="text-gray-300 hover:text-white">{t("footer.relocation")}</Link>
                   </li>
                   <li>
-                    <Link to="#contact" className="text-gray-300 hover:text-white">{t("contact")}</Link>
-                  </li>
-                  <li>
                     <Link to="/blog" className="text-gray-300 hover:text-white">
                       {language === "en" ? "Blog" : "Блог"}
                     </Link>
-                  </li>
-                  <li>
-                    <a
-                      href="https://calabriaexplorer.vercel.app/flights"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-gray-300 hover:text-white"
-                    >
-                      {language === "en" ? "How to get there" : "Как добраться"}
-                    </a>
                   </li>
                 </ul>
               </nav>


### PR DESCRIPTION
## Summary
- clean up Quick Links footer list by removing Contact and How to get there

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68717972d8d0832cb567d50ff9c94ba5