### PR TITLE
Add AdSense to donkey game

### DIFF
--- a/public/donkey/index.html
+++ b/public/donkey/index.html
@@ -6,6 +6,7 @@
 <base href="/donkey/">
 <title>Donkey & Brasilena</title>
 <link rel="stylesheet" href="styles.css">
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6361433510552253" crossorigin="anonymous"></script>
 </head>
 <body>
 <audio id="bgMusic" src="sounds/pixelated-dreams-20240608-171413.m4r" loop autoplay></audio>
@@ -16,12 +17,16 @@
 <div id="gameContainer">
 <canvas id="game"></canvas>
 <div id="overlay">
-<div id="finalScore"></div>
-<iframe src="ads/fullscreen.html" style="width:80%;height:50%;border:none;margin:20px 0;"></iframe>
-<button id="playAgain"></button>
-</div>
-</div>
-<iframe id="adBanner" src="ads/banner.html"></iframe>
-<script src="game.js"></script>
+  <div id="finalScore"></div>
+  <div class="fullscreen-ad-wrapper">
+    <ins class="adsbygoogle" style="display:inline-block;width:320px;height:250px" data-ad-client="ca-pub-6361433510552253" data-ad-slot="1234567890"></ins>
+    <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+  </div>
+  <button id="playAgain"></button>
+  </div>
+  </div>
+  <ins class="adsbygoogle banner-ad" style="display:block" data-ad-client="ca-pub-6361433510552253" data-ad-slot="1234567890" data-ad-format="auto" data-full-width-responsive="true"></ins>
+  <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+  <script src="game.js"></script>
 </body>
 </html>

--- a/public/donkey/styles.css
+++ b/public/donkey/styles.css
@@ -1,6 +1,9 @@
 body,html{margin:0;padding:0;height:100%;overflow:hidden;font-family:sans-serif;background:#f0f0f0;}
 #gameContainer{position:relative;width:100%;height:100vh;background:#a3d9ff;touch-action:none;}
 #game{background:#e0f7ff;display:block;margin:0 auto;}
-#adBanner{position:fixed;bottom:0;left:0;width:100%;height:50px;border:none;z-index:5;}
+.banner-ad{position:fixed;bottom:0;left:0;width:100%;height:50px;z-index:9999;background:#fff;text-align:center;}
+@media (max-width:600px){.banner-ad{height:90px;}}
+.fullscreen-ad-wrapper{display:flex;justify-content:center;align-items:center;width:100%;height:100%;background:#eee;}
+@media (max-width:600px){.fullscreen-ad-wrapper ins{width:300px !important;height:250px !important;}}
 #overlay{position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);color:#fff;display:flex;flex-direction:column;justify-content:center;align-items:center;font-size:24px;display:none;z-index:10;}
 #overlay button{margin-top:20px;font-size:24px;padding:10px 20px;}


### PR DESCRIPTION
## Summary
- load global AdSense script in donkey game
- replace placeholder ads with AdSense units
- style banner and fullscreen ad slots

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68725f706ee4832ca75f46d5636622e5