### PR TITLE
Fix banner overlap in donkey game

### DIFF
--- a/public/donkey/styles.css
+++ b/public/donkey/styles.css
@@ -1,8 +1,8 @@
 body,html{margin:0;padding:0;height:100%;overflow:hidden;font-family:sans-serif;background:#f0f0f0;}
-#gameContainer{position:relative;width:100%;height:100vh;background:#a3d9ff;touch-action:none;}
+#gameContainer{position:relative;width:100%;height:100vh;background:#a3d9ff;touch-action:none;padding-bottom:50px;}
 #game{background:#e0f7ff;display:block;margin:0 auto;}
 .banner-ad{position:fixed;bottom:0;left:0;width:100%;height:50px;z-index:9999;background:#fff;text-align:center;}
-@media (max-width:600px){.banner-ad{height:90px;}}
+@media (max-width:600px){#gameContainer{padding-bottom:90px;}.banner-ad{height:90px;}}
 .fullscreen-ad-wrapper{display:flex;justify-content:center;align-items:center;width:100%;height:100%;background:#eee;}
 @media (max-width:600px){.fullscreen-ad-wrapper ins{width:300px !important;height:250px !important;}}
 #overlay{position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);color:#fff;display:flex;flex-direction:column;justify-content:center;align-items:center;font-size:24px;display:none;z-index:10;}


### PR DESCRIPTION
## Summary
- add bottom padding to donkey `#gameContainer` so game content isn't overlapped by the ad banner

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872669a00d8832c9e507ce1346512d2