### PR TITLE
Remove Contact & About nav items

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -201,15 +201,9 @@ const Layout = ({ children, colorScheme = "default", title, description, image, 
                 <Link to="/tours" className="font-medium" aria-label="Tours and excursions">{t("tours")}</Link>
               </NavigationMenuItem>
               <NavigationMenuItem className="px-2">
-                <Link to="#about" className="font-medium" aria-label="About Calabria">{t("about")}</Link>
-              </NavigationMenuItem>
-              <NavigationMenuItem className="px-2">
                 <Link to="/blog" className="font-medium" aria-label={language === "en" ? "Blog" : "Блог"}>
                   {language === "en" ? "Blog" : "Блог"}
                 </Link>
-              </NavigationMenuItem>
-              <NavigationMenuItem className="px-2">
-                <Link to="#contact" className="font-medium" aria-label="Contact us">{t("contact")}</Link>
               </NavigationMenuItem>
               <NavigationMenuItem className="px-2">
                 <Button 

--- a/src/components/ui/mobile-menu.tsx
+++ b/src/components/ui/mobile-menu.tsx
@@ -44,20 +44,6 @@ const MobileMenu = () => {
             >
               {t("tours")}
             </Link>
-            <Link 
-              to="#about" 
-              className="text-lg font-medium py-2"
-              onClick={() => setIsOpen(false)}
-            >
-              {t("about")}
-            </Link>
-            <Link 
-              to="#contact" 
-              className="text-lg font-medium py-2"
-              onClick={() => setIsOpen(false)}
-            >
-              {t("contact")}
-            </Link>
             
             <div className="border-t pt-4 mt-4">
               <div className="flex items-center gap-2 mb-3">


### PR DESCRIPTION
## Summary
- remove `About` and `Contact` links from desktop and mobile navigation menus

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872ce7b9a90832c8b5bbd1f194029a6