### PR TITLE
Fix lane conflicts in Donkey game

### DIFF
--- a/public/donkey/game.js
+++ b/public/donkey/game.js
@@ -140,6 +140,7 @@ function drawHearts() {
 
 let gameOver=false;
 function loop(ts){
+  occupiedLanes = new Set();
   if(gameOver) return;
   const delta = ts - lastTime;
   lastTime = ts;
@@ -199,7 +200,6 @@ function loop(ts){
   ctx.fillStyle='#000';
   ctx.font='20px sans-serif';
   ctx.fillText(`${texts.score}: ${score}`,10,30);
-  occupiedLanes.clear();
   requestAnimationFrame(loop);
 }
 


### PR DESCRIPTION
## Summary
- ensure lanes get reset each frame to prevent simultaneous spawns
- remove leftover lane clearing at loop end

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68734bd309d4832c8fea669463272e87