### PR TITLE
Disable AdSense banner for mobile debugging

### DIFF
--- a/public/donkey/game.js
+++ b/public/donkey/game.js
@@ -46,7 +46,7 @@ function loadAssets(){
 }
 
 function resize() {
-  const bannerHeight = 50;
+  const bannerHeight = 0; // баннер временно отключён
   width = canvas.width = window.innerWidth;
   height = canvas.height = window.innerHeight - bannerHeight;
   laneWidth = width / lanes;

--- a/public/donkey/index.html
+++ b/public/donkey/index.html
@@ -36,6 +36,8 @@
   <button id="playAgain"></button>
   </div>
   </div>
+  <!-- 🔧 Временно отключаем баннер AdSense -->
+  <!--
   <div class="ad-container">
     <ins class="adsbygoogle"
          style="display:block;width:100%;height:60px"
@@ -47,6 +49,7 @@
          (adsbygoogle = window.adsbygoogle || []).push({});
     </script>
   </div>
+  -->
   <script src="game.js"></script>
 </body>
 </html>

--- a/public/donkey/styles.css
+++ b/public/donkey/styles.css
@@ -95,6 +95,7 @@ canvas {
 }
 
 /* Container for bottom ad */
+/*
 .ad-container {
   position: fixed;
   bottom: 0;
@@ -103,3 +104,4 @@ canvas {
   z-index: 1000;
   background: #fff;
 }
+*/


### PR DESCRIPTION
## Summary
- comment out the AdSense banner block in the Donkey index page
- hide `.ad-container` styles
- set `bannerHeight` to `0` so the game uses the full viewport

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68737b6deab8832c9fc408700bc92094