### PR TITLE
Add desktop iPhone frame styling

### DIFF
--- a/public/donkey/game.js
+++ b/public/donkey/game.js
@@ -32,6 +32,14 @@ let texts = {};
 let assetsLoaded = false;
 let langLoaded = false;
 
+function updateIphoneMode() {
+  if (window.innerWidth >= 768) {
+    document.body.classList.add('iphone-mode');
+  } else {
+    document.body.classList.remove('iphone-mode');
+  }
+}
+
 function checkReady(){
   if(assetsLoaded && langLoaded) startGame();
 }
@@ -46,6 +54,7 @@ function loadAssets(){
 }
 
 function resize() {
+  updateIphoneMode();
   const bannerHeight = 0; // баннер временно отключён
   width = canvas.width = window.innerWidth;
   height = canvas.height = window.innerHeight - bannerHeight;

--- a/public/donkey/index.html
+++ b/public/donkey/index.html
@@ -20,6 +20,7 @@
 <audio id="bgMusic" src="sounds/pixelated-dreams-20240608-171413.m4r" loop autoplay></audio>
 <audio id="catchSound" src="sounds/catch.mp3"></audio>
 <audio id="failSound" src="sounds/fail.mp3"></audio>
+<div id="iphone-wrapper">
 <div id="gameContainer">
 <canvas id="game"></canvas>
 <div id="overlay">
@@ -32,6 +33,7 @@
     <script>
          (adsbygoogle = window.adsbygoogle || []).push({});
     </script>
+  </div>
   </div>
   <button id="playAgain"></button>
   </div>

--- a/public/donkey/styles.css
+++ b/public/donkey/styles.css
@@ -105,3 +105,22 @@ canvas {
   background: #fff;
 }
 */
+
+@media (min-width: 768px) {
+  body.iphone-mode #iphone-wrapper {
+    position: relative;
+    width: 430px;
+    height: 932px;
+    margin: 0 auto;
+    background: url('/donkey/iphone_frame.png') no-repeat center center;
+    background-size: contain;
+  }
+
+  body.iphone-mode #game {
+    position: absolute;
+    top: 60px;
+    left: 26px;
+    width: 378px;
+    height: 812px;
+  }
+}


### PR DESCRIPTION
## Summary
- wrap the donkey game in a new `iphone-wrapper` container
- style the wrapper and game canvas for desktop screens only
- toggle `iphone-mode` class based on window width

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873e9654478832ca09870c5c92ffdbf