### PR TITLE
Add desktop iPhone frame for Donkey game

### DIFF
--- a/public/donkey/game.js
+++ b/public/donkey/game.js
@@ -1,4 +1,4 @@
-const canvas = document.getElementById('game');
+const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 const overlay = document.getElementById('overlay');
 const playBtn = document.getElementById('playAgain');
@@ -56,8 +56,13 @@ function loadAssets(){
 function resize() {
   updateIphoneMode();
   const bannerHeight = 0; // баннер временно отключён
-  width = canvas.width = window.innerWidth;
-  height = canvas.height = window.innerHeight - bannerHeight;
+  if (window.innerWidth >= 768) {
+    width = canvas.width = 393;
+    height = canvas.height = 852;
+  } else {
+    width = canvas.width = window.innerWidth;
+    height = canvas.height = window.innerHeight - bannerHeight;
+  }
   laneWidth = width / lanes;
   donkeyX = laneWidth * donkeyLane + laneWidth / 2;
 

--- a/public/donkey/index.html
+++ b/public/donkey/index.html
@@ -21,9 +21,9 @@
 <audio id="catchSound" src="sounds/catch.mp3"></audio>
 <audio id="failSound" src="sounds/fail.mp3"></audio>
 <div id="iphone-wrapper">
-<div id="gameContainer">
-<canvas id="game"></canvas>
-<div id="overlay">
+  <img src="Iphone16Pro" id="iphone-frame" alt="iPhone 16 Pro Frame" />
+  <canvas id="gameCanvas" width="393" height="852"></canvas>
+  <div id="overlay">
   <div id="finalScore"></div>
   <div id="fullscreenAdContainer" class="fullscreen-ad-wrapper">
     <ins class="adsbygoogle fullscreen-ad"
@@ -36,8 +36,7 @@
   </div>
   </div>
   <button id="playAgain"></button>
-  </div>
-  </div>
+</div>
   <!-- 🔧 Временно отключаем баннер AdSense -->
   <!--
   <div class="ad-container">

--- a/public/donkey/styles.css
+++ b/public/donkey/styles.css
@@ -8,31 +8,35 @@ body, html {
 }
 
 /* \u041e\u0433\u0440\u0430\u043d\u0438\u0447\u0438\u0432\u0430\u0435\u043c \u0432\u044b\u0441\u043e\u0442\u0443 canvas */
-canvas {
-  display: block;
-  margin: 0 auto;
-  max-width: 100%;
-  height: calc(var(--vh, 1vh) * 100 - 60px); /* Уменьшаем высоту на высоту баннера */
-  box-sizing: border-box;
-}
-
-#gameContainer {
+#iphone-wrapper {
   position: relative;
   width: 100%;
   height: calc(var(--vh, 1vh) * 100 - 60px);
-  background: #a3d9ff;
-  touch-action: none;
+  margin: 0 auto;
 }
 
-#game {
-  display: block;
+#iphone-frame {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  pointer-events: none;
+  display: none;
+}
+
+#gameCanvas {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100vw;
   height: calc(var(--vh, 1vh) * 100 - 60px);
+  z-index: 2;
 }
 
 @media (max-width: 600px) {
-  #gameContainer,
-  #game {
+  #gameCanvas {
     height: calc(var(--vh, 1vh) * 100 - 60px);
   }
 }
@@ -107,20 +111,15 @@ canvas {
 */
 
 @media (min-width: 768px) {
-  body.iphone-mode #iphone-wrapper {
-    position: relative;
-    width: 430px;
-    height: 932px;
-    margin: 0 auto;
-    background: url('/donkey/iphone_frame.png') no-repeat center center;
-    background-size: contain;
+  body.iphone-mode #iphone-frame {
+    display: block;
   }
-
-  body.iphone-mode #game {
-    position: absolute;
-    top: 60px;
-    left: 26px;
-    width: 378px;
-    height: 812px;
+  body.iphone-mode #iphone-wrapper {
+    width: 393px;
+    height: 852px;
+  }
+  body.iphone-mode #gameCanvas {
+    width: 393px;
+    height: 852px;
   }
 }


### PR DESCRIPTION
## Summary
- embed canvas in new iPhone 16 Pro frame
- adapt CSS for frame and canvas behaviour
- update game logic for fixed desktop canvas size

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6874d88f581c832c8aa790a7dbac8f89