### PR TITLE
Add Pucci Pane logo to Cornetto Clicker

### DIFF
--- a/public/cornettoclicker/index.html
+++ b/public/cornettoclicker/index.html
@@ -23,13 +23,17 @@
    top:10px;
    left:50%;
    transform:translateX(-50%);
-   display:flex;
-   gap:15px;
-   font-size:1.2em;
- }
- #bigCroissant{
-   position:absolute;
-   left:50%;
+  display:flex;
+  gap:15px;
+  font-size:1.2em;
+}
+#logo {
+  height: 35px;
+  object-fit: contain;
+}
+#bigCroissant{
+  position:absolute;
+  left:50%;
    top:50%;
    transform:translate(-50%,-50%);
    font-size:50px;
@@ -74,6 +78,7 @@
 <div id="game">
  <div id="bigCroissant">🥐</div>
  <div id="scoreboard">
+  <img id="logo" src="logoPuciPane.png" alt="Pucci Pane" />
   <span id="score">0/500</span>
   <span id="missed">0/10</span>
   <span id="timer">0.0000000</span>


### PR DESCRIPTION
## Summary
- include a Pucci Pane logo at the start of the Cornetto Clicker scoreboard
- size the logo to 35px high so it stays compact

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6874fd1e9d34832c926c3038eade69dc