### PR TITLE
Add logo alignment and reliable audio

### DIFF
--- a/public/cornettoclicker/index.html
+++ b/public/cornettoclicker/index.html
@@ -18,18 +18,23 @@
    width:100%;
    height:100vh;
  }
- #scoreboard{
-   position:absolute;
-   top:10px;
-   left:50%;
-   transform:translateX(-50%);
-   display:flex;
-   gap:15px;
-   font-size:1.2em;
- }
- #bigCroissant{
-   position:absolute;
-   left:50%;
+#scoreboard{
+  position:absolute;
+  top:10px;
+  left:50%;
+  transform:translateX(-50%);
+  display:flex;
+  align-items:center;
+  gap:15px;
+  font-size:1.2em;
+}
+#logo {
+  height: 35px;
+  object-fit: contain;
+}
+#bigCroissant{
+  position:absolute;
+  left:50%;
    top:50%;
    transform:translate(-50%,-50%);
    font-size:50px;
@@ -74,6 +79,7 @@
 <div id="game">
  <div id="bigCroissant">🥐</div>
  <div id="scoreboard">
+  <img id="logo" src="logoPuciPane.png" alt="Pucci Pane" />
   <span id="score">0/500</span>
   <span id="missed">0/10</span>
   <span id="timer">0.0000000</span>
@@ -91,6 +97,7 @@
 const music = new Audio('sounds/music.mp3');
 music.loop = true;
 music.volume = 0.4;
+music.preload = 'auto';
 
 function tryPlayMusic() {
   if (music && music.paused) {
@@ -101,9 +108,12 @@ function tryPlayMusic() {
 }
 document.addEventListener('pointerdown', tryPlayMusic, { once: true });
 document.addEventListener('touchstart', tryPlayMusic, { once: true });
+document.addEventListener('click', tryPlayMusic, { once: true });
 
 const collectSound = new Audio('sounds/collect.mp3');
 const fireSound = new Audio('sounds/fire.mp3');
+collectSound.preload = 'auto';
+fireSound.preload = 'auto';
 (function(){
  const lang = (navigator.language||'en').slice(0,2);
  const texts = {


### PR DESCRIPTION
## Summary
- keep scoreboard items aligned by centering them
- preload Cornetto Clicker audio and listen for standard `click` events so sounds start reliably

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6874fd1e9d34832c926c3038eade69dc