### PR TITLE
Fix scoreboard logo layout

### DIFF
--- a/public/cornettoclicker/index.html
+++ b/public/cornettoclicker/index.html
@@ -18,19 +18,25 @@
    width:100%;
    height:100vh;
  }
-#scoreboard{
-  position:absolute;
-  top:10px;
-  left:50%;
-  transform:translateX(-50%);
- display:flex;
-  align-items:center;
-  gap:15px;
-  font-size:1.2em;
+#scoreboard {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 10px 20px;
+  font-size: 1.2em;
+  max-width: 90vw;
+  padding: 0 10px;
 }
+
 #logo {
   height: 35px;
-  object-fit: contain;
+  width: auto;
+  margin-right: 15px;
 }
 #bigCroissant{
   position:absolute;
@@ -79,7 +85,7 @@
 <div id="game">
  <div id="bigCroissant">🥐</div>
  <div id="scoreboard">
-  <img id="logo" src="logoPuciPane.png" alt="Pucci Pane" />
+  <img id="logo" src="logoPuciPane.png" alt="Pucci Pane logo" />
   <span id="score">0/500</span>
   <span id="missed">0/10</span>
   <span id="timer">0.0000000</span>


### PR DESCRIPTION
## Summary
- add logo to scoreboard
- make scoreboard responsive and flexible

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875228dc394832c9670730ec1bdad2e