### PR TITLE
Add Pucci Pane logo to Cornetto Clicker

### DIFF
--- a/public/cornettoclicker/index.html
+++ b/public/cornettoclicker/index.html
@@ -34,9 +34,15 @@
 }
 
 #logo {
-  height: 35px;
-  width: auto;
-  margin-right: 15px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  width: 80px;
+}
+@media(min-width: 600px){
+  #logo {
+    width: 120px;
+  }
 }
 #bigCroissant{
   position:absolute;
@@ -83,9 +89,9 @@
 </head>
 <body>
 <div id="game">
+ <img id="logo" src="logoPuciPane.png" alt="Pucci Pane logo">
  <div id="bigCroissant">🥐</div>
  <div id="scoreboard">
-  <img id="logo" src="logoPuciPane.png" alt="Pucci Pane logo" />
   <span id="score">0/500</span>
   <span id="missed">0/10</span>
   <span id="timer">0.0000000</span>


### PR DESCRIPTION
## Summary
- display `logoPuciPane.png` in the top-left corner of the Cornetto Clicker page
- adjust CSS so the logo size responds to viewport width

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687528493200832c8ebe1b88b098933c