### PR TITLE
Improve multilingual SEO signals and crawler accessibility

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,7 +2,6 @@ User-agent: *
 Allow: /
 Disallow: /api/
 Disallow: /admin/
-Disallow: /*.json$
 Disallow: /src/
 
 User-agent: Googlebot

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -42,11 +42,20 @@ const SEOHead: React.FC<SEOHeadProps> = ({
 }) => {
   const location = useLocation();
   const { language } = useLanguage();
-  // canonical без query-параметров пагинации/сортировки
+  const stripLanguagePrefix = (path: string) => path.replace(/^\/(en|ru)(?=\/|$)/, "") || "/";
   const cleanPath = location.pathname;
   const origin = typeof window !== "undefined" ? window.location.origin : "";
-  const languageQuery = language === "ru" ? "?lang=ru" : "?lang=en";
-  const url = canonical || absoluteUrl(`${cleanPath}${languageQuery}`);
+  const isPathLocalized = /^\/(en|ru)(\/|$)/.test(cleanPath);
+  const toLocalizedUrl = (targetLanguage: "en" | "ru") => {
+    if (isPathLocalized) {
+      return `${origin}${cleanPath.replace(/^\/(en|ru)(?=\/|$)/, `/${targetLanguage}`)}`;
+    }
+    const params = new URLSearchParams(location.search);
+    params.set("lang", targetLanguage);
+    const query = params.toString();
+    return `${origin}${cleanPath}${query ? `?${query}` : ""}`;
+  };
+  const url = canonical || (isPathLocalized ? `${origin}${cleanPath}` : toLocalizedUrl(language));
 
   // Google Analytics (gtag.js)
   React.useEffect(() => {
@@ -187,6 +196,7 @@ const SEOHead: React.FC<SEOHeadProps> = ({
 
   // Meta теги (SPA-навигация)
   React.useEffect(() => {
+    document.documentElement.lang = language;
     if (title) document.title = title;
     if (description) {
       let descTag = document.querySelector("meta[name='description']");
@@ -207,7 +217,7 @@ const SEOHead: React.FC<SEOHeadProps> = ({
       document.head.appendChild(robotsTag);
     }
     (robotsTag as HTMLMetaElement).content = robotsCnt;
-  }, [title, description, noIndex, location.search]);
+  }, [title, description, noIndex, location.search, language]);
 
   // OG / Twitter / hreflang и theme-color
   React.useEffect(() => {
@@ -263,10 +273,10 @@ const SEOHead: React.FC<SEOHeadProps> = ({
     // hreflang/alternate
     Array.from(document.querySelectorAll("link[rel='alternate']")).forEach(l => l.remove());
 
-    const normalizedPath = location.pathname.replace(/^\/(en|ru)(\/|$)/, "/") || "/";
+    const normalizedPath = stripLanguagePrefix(location.pathname);
     const locales = [
-      { hreflang: "ru", url: `${origin}${normalizedPath}?lang=ru` },
-      { hreflang: "en", url: `${origin}${normalizedPath}?lang=en` },
+      { hreflang: "ru", url: toLocalizedUrl("ru") },
+      { hreflang: "en", url: toLocalizedUrl("en") },
     ];
     locales.forEach(loc => {
       const link = document.createElement("link");

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -157,6 +157,17 @@ const translations = {
 
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
 
+const readLanguageCookie = (): Language | null => {
+  if (typeof document === "undefined") return null;
+  const raw = document.cookie
+    .split(";")
+    .map((item) => item.trim())
+    .find((item) => item.startsWith("preferred-language="));
+  if (!raw) return null;
+  const value = raw.split("=")[1];
+  return value === "ru" || value === "en" ? value : null;
+};
+
 const getLanguageFromUrl = (): Language | null => {
   if (typeof window === "undefined") return null;
 
@@ -179,13 +190,21 @@ const getInitialLanguage = (): Language => {
   if (urlLanguage) return urlLanguage;
 
   if (typeof window !== "undefined") {
+    const cookieLanguage = readLanguageCookie();
+    if (cookieLanguage) {
+      return cookieLanguage;
+    }
+
     const saved = window.localStorage.getItem("preferred-language");
     if (saved === "ru" || saved === "en") {
       return saved;
     }
 
-    const acceptLanguage = window.navigator.language.toLowerCase();
-    if (acceptLanguage.startsWith("ru")) {
+    const browserLanguages = window.navigator.languages?.length
+      ? window.navigator.languages
+      : [window.navigator.language];
+    const hasRussian = browserLanguages.some((lang) => lang.toLowerCase().startsWith("ru"));
+    if (hasRussian) {
       return "ru";
     }
   }
@@ -202,8 +221,11 @@ export const LanguageProvider: React.FC<{children: ReactNode}> = ({ children }) 
     window.localStorage.setItem("preferred-language", nextLanguage);
     document.cookie = `preferred-language=${nextLanguage}; path=/; max-age=31536000; samesite=lax`;
 
+    const isPathLocalized = /^\/(ru|en)(\/|$)/.test(window.location.pathname);
     const params = new URLSearchParams(window.location.search);
-    params.set("lang", nextLanguage);
+    if (!isPathLocalized) {
+      params.set("lang", nextLanguage);
+    }
     const nextQuery = params.toString();
     const nextUrl = `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ""}${window.location.hash}`;
     window.history.replaceState({}, "", nextUrl);


### PR DESCRIPTION
### Motivation
- Reduce duplicated-language indexing and improve hreflang/canonical signals for mixed prefix/query localization to help Google, Yandex and AI crawlers index the correct language pages.
- Allow AI/search bots to render JavaScript-localized content by removing a blocking directive for JSON localization files.
- Ensure SPA head/meta updates (OG, robots, canonical, hreflang) and `html[lang]` reflect the active UI language for accessibility and accurate parsing by crawlers.

### Description
- Removed `Disallow: /*.json$` from `public/robots.txt` so translation and other JSON assets can be fetched by render-capable bots (file: `public/robots.txt`).
- Improved localized URL and canonical/hreflang generation in `src/components/SEOHead.tsx` to support both path-prefix (`/en/`, `/ru/`) and query (`?lang=`) strategies, and set `document.documentElement.lang` on language change (file: `src/components/SEOHead.tsx`).
- Strengthened language detection and persistence in `src/contexts/LanguageContext.tsx` with new cookie read, priority order `URL > cookie > localStorage > browser languages`, and logic to avoid forcing `?lang=` when the path already uses a language prefix (file: `src/contexts/LanguageContext.tsx`).
- Preserved SPA-safe behavior for canonical links and schema injection so pages remain self-canonical and have consistent `og:locale`/`og:locale:alternate` values (changes in `src/components/SEOHead.tsx`).

### Testing
- Ran the production build with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2c437a128832ca1ca187c0ba78df0)