### PR TITLE
Rename donkey game to “Cirò Tap” (page title, heading, and social metadata)

### DIFF
--- a/public/donkey/index.html
+++ b/public/donkey/index.html
@@ -12,11 +12,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
 <base href="/donkey/">
-<title>Donkey & Brasilena</title>
+<title>Cirò Tap</title>
+<meta property="og:title" content="Cirò Tap">
+<meta name="twitter:title" content="Cirò Tap">
 <link rel="stylesheet" href="styles.css">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6361433510552253" crossorigin="anonymous"></script>
 </head>
 <body>
+<h1 class="game-title">Cirò Tap</h1>
 <audio id="bgMusic" src="sounds/pixelated-dreams-20240608-171413.m4r" loop autoplay></audio>
 <audio id="catchSound" src="sounds/catch.mp3"></audio>
 <audio id="failSound" src="sounds/fail.mp3"></audio>

--- a/public/donkey/styles.css
+++ b/public/donkey/styles.css
@@ -7,6 +7,13 @@ body, html {
   background: #f0f0f0;
 }
 
+.game-title {
+  margin: 12px 0 8px;
+  text-align: center;
+  font-size: 1.6rem;
+  line-height: 1.2;
+}
+
 /* \u041e\u0433\u0440\u0430\u043d\u0438\u0447\u0438\u0432\u0430\u0435\u043c \u0432\u044b\u0441\u043e\u0442\u0443 canvas */
 #iphone-wrapper {
   position: relative;


### PR DESCRIPTION
### Motivation
- Align the donkey mini-game branding and social preview text with the requested name using the proper UTF-8 character `ò` (U+00F2). 
- Ensure the browser tab, on-page heading, and social previews (`og:title` / `twitter:title`) all show the same visible title.

### Description
- Updated `public/donkey/index.html` to set the `<title>` to `Cirò Tap`, and added `<meta property="og:title">` and `<meta name="twitter:title">` with `Cirò Tap`.
- Added an on-page heading `<h1 class="game-title">Cirò Tap</h1>` in `public/donkey/index.html` so the visible page title matches the tab and metadata.
- Added minimal styling for `.game-title` in `public/donkey/styles.css` to keep the heading centered and readable while preserving UTF-8 encoding.

### Testing
- Ran repository searches with `rg -n --hidden -g '!node_modules/**' -g '!.next/**' -g '!out/**' -g '!dist/**' "Cirò Tap|BRASILENA TAP|Donkey & Brasilena|og:title|twitter:title"` and verified `Cirò Tap` appears in `<title>`, `og:title`, `twitter:title`, and the page heading in `public/donkey/index.html`.
- Ran `rg -n --hidden -g '!node_modules/**' -g '!.next/**' -g '!out/**' -g '!dist/**' "BRASILENA TAP" .` and confirmed there are no remaining matches.
- All automated checks above completed successfully (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2c6ff3d2c832c900d8418b6fac563)