### PR TITLE
Add Threads icon/link to footer social links

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -18,6 +18,19 @@ interface LayoutProps {
   preloadImages?: string[];
 }
 
+const ThreadsIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className}
+    aria-hidden="true"
+  >
+    <path d="M16.5 4.5c-2.5 0-4.5 2-4.5 4.5v6c0 2.5 2 4.5 4.5 4.5s4.5-2 4.5-4.5v-2h-3v2c0 .8-.7 1.5-1.5 1.5s-1.5-.7-1.5-1.5V9c0-1.7 1.3-3 3-3s3 1.3 3 3v3h3V9c0-2.5-2-4.5-4.5-4.5z" />
+    <circle cx="6.5" cy="14.5" r="2.5" />
+  </svg>
+);
+
 const Layout = ({ children, colorScheme = "default", title, description, image, preloadImages }: LayoutProps) => {
   const { language, setLanguage, t } = useLanguage();
   
@@ -54,6 +67,11 @@ const Layout = ({ children, colorScheme = "default", title, description, image, 
           href: "https://www.instagram.com/maria_nedvizimost_calabria?igsh=b3h1aHBzeWhpeG4z",
           icon: Instagram,
           label: "Follow us on Instagram"
+        },
+        {
+          href: "https://www.threads.com/@maria_nedvizimost_calabria",
+          icon: ThreadsIcon,
+          label: "Threads"
         }
       ];
     } else {
@@ -62,6 +80,11 @@ const Layout = ({ children, colorScheme = "default", title, description, image, 
           href: "https://www.instagram.com/maria_nedvizimost_calabria?igsh=b3h1aHBzeWhpeG4z",
           icon: Instagram,
           label: "Подписывайтесь в Instagram"
+        },
+        {
+          href: "https://www.threads.com/@maria_nedvizimost_calabria",
+          icon: ThreadsIcon,
+          label: "Threads"
         },
         {
           href: "https://t.me/s/CiroMarinaVibe",


### PR DESCRIPTION
### Motivation
- Provide a Threads social link in the footer so users can reach the profile `https://www.threads.com/@maria_nedvizimost_calabria` and keep social links consistent across languages.

### Description
- Added a `ThreadsIcon` SVG component in `src/components/layout/Layout.tsx` and wired it into `getSocialMediaLinks()` for both `en` and `ru` language variants so the icon is rendered by the same pipeline as other icons.
- The Threads entry uses the same rendering as other items so the anchor is created with `target="_blank" rel="noopener noreferrer"` and `aria-label="Threads"`, and the icon receives the same `w-6 h-6` class so size, color, hover effects and layout remain identical.
- No extra CSS was needed because the icon inherits existing Tailwind classes and is placed inside the same `flex space-x-4` social container (`src/components/layout/Layout.tsx`).

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm run build` and it completed successfully (production bundle generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2d0d510a8832c8edd70032f5f86e1)