### PR TITLE
Add Threads profile to Russian social page

### DIFF
--- a/public/ru/social.html
+++ b/public/ru/social.html
@@ -39,6 +39,7 @@
       "https://dzen.ru/id/66f27f02053e7469931f7e54",
       "https://t.me/CiroMarinaVibe",
       "https://www.instagram.com/maria_nedvizimost_calabria?igsh=b3h1aHBzeWhpeG4z",
+      "https://www.threads.com/@maria_nedvizimost_calabria",
       "https://calabriaexplorer.vercel.app"
     ]
   }
@@ -199,6 +200,7 @@
         <li class="social-item"><span class="mark" aria-hidden="true">✔️</span><a href="https://dzen.ru/id/66f27f02053e7469931f7e54" target="_blank" rel="me noopener noreferrer">Блог в Яндекс.Дзен</a></li>
         <li class="social-item"><span class="mark" aria-hidden="true">✔️</span><a href="https://t.me/CiroMarinaVibe" target="_blank" rel="me noopener noreferrer">Канал в Telegram</a></li>
         <li class="social-item"><span class="mark" aria-hidden="true">✔️</span><a href="https://www.instagram.com/maria_nedvizimost_calabria?igsh=b3h1aHBzeWhpeG4z" target="_blank" rel="me noopener noreferrer">Блог в Instagram</a></li>
+        <li class="social-item"><span class="mark" aria-hidden="true">✔️</span><a href="https://www.threads.com/@maria_nedvizimost_calabria" target="_blank" rel="me noopener noreferrer">Блог в Threads</a></li>
         <li class="social-item"><span class="mark" aria-hidden="true">✔️</span><a href="https://calabriaexplorer.vercel.app" target="_blank" rel="me noopener noreferrer">Официальный сайт</a></li>
       </ul>
     </section>

--- a/public/ru/social/index.html
+++ b/public/ru/social/index.html
@@ -39,6 +39,7 @@
       "https://dzen.ru/id/66f27f02053e7469931f7e54",
       "https://t.me/CiroMarinaVibe",
       "https://www.instagram.com/maria_nedvizimost_calabria?igsh=b3h1aHBzeWhpeG4z",
+      "https://www.threads.com/@maria_nedvizimost_calabria",
       "https://calabriaexplorer.vercel.app"
     ]
   }
@@ -199,6 +200,7 @@
         <li class="social-item"><span class="mark" aria-hidden="true">✔️</span><a href="https://dzen.ru/id/66f27f02053e7469931f7e54" target="_blank" rel="me noopener noreferrer">Блог в Яндекс.Дзен</a></li>
         <li class="social-item"><span class="mark" aria-hidden="true">✔️</span><a href="https://t.me/CiroMarinaVibe" target="_blank" rel="me noopener noreferrer">Канал в Telegram</a></li>
         <li class="social-item"><span class="mark" aria-hidden="true">✔️</span><a href="https://www.instagram.com/maria_nedvizimost_calabria?igsh=b3h1aHBzeWhpeG4z" target="_blank" rel="me noopener noreferrer">Блог в Instagram</a></li>
+        <li class="social-item"><span class="mark" aria-hidden="true">✔️</span><a href="https://www.threads.com/@maria_nedvizimost_calabria" target="_blank" rel="me noopener noreferrer">Блог в Threads</a></li>
         <li class="social-item"><span class="mark" aria-hidden="true">✔️</span><a href="https://calabriaexplorer.vercel.app" target="_blank" rel="me noopener noreferrer">Официальный сайт</a></li>
       </ul>
     </section>


### PR DESCRIPTION
### Motivation
- Add Maria's Threads account to the Russian social landing page so the `/ru/social` page lists the new social profile and structured data includes it for discovery.

### Description
- Inserted `https://www.threads.com/@maria_nedvizimost_calabria` into the JSON-LD `sameAs` array in both `public/ru/social.html` and `public/ru/social/index.html`.
- Added a new list item linking to Threads in the visible social links list in both files to keep the two static variants synchronized.
- Changes were applied via a small script to update both files consistently.

### Testing
- Ran the update script which completed without errors.
- Reviewed the produced differences with `git diff -- public/ru/social.html public/ru/social/index.html` and confirmed the Threads URL is present in both the JSON-LD and the links list.
- Printed and inspected the relevant file regions with `nl` and `sed` to validate the inserted `sameAs` entry and the new list item were correctly written.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a292b7a4832c81fc84a9f461a5d0)