### PR TITLE
SEO 2026: refresh robots.txt crawler policy

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,16 +1,29 @@
+# Calabria Explorer robots policy (updated 2026-05-08)
+# Search indexing bots
 User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
 Allow: /
 
 User-agent: YandexBot
 Allow: /
 
-User-agent: GPTBot
+# AI retrieval bots used for search answers
+User-agent: OAI-SearchBot
 Allow: /
 
-User-agent: ClaudeBot
+User-agent: PerplexityBot
 Allow: /
+
+# AI training bots (blocked)
+User-agent: GPTBot
+Disallow: /
 
 User-agent: Google-Extended
-Allow: /
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
 
 Sitemap: https://calabriaexplorer.vercel.app/sitemap.xml


### PR DESCRIPTION
### Motivation
- Update `public/robots.txt` to implement a 2026-style crawler policy that separates retrieval/indexing access from AI training access and makes allowed/disallowed bots explicit.

### Description
- Modified `public/robots.txt`: added a dated header comment, allowed `Googlebot`, `Bingbot`, and `YandexBot`, explicitly allowed retrieval-focused bots `OAI-SearchBot` and `PerplexityBot`, blocked training-focused bots `GPTBot`, `Google-Extended`, and `ClaudeBot`, and preserved the `Sitemap` directive.

### Testing
- Ran verification and commit commands (`git add public/robots.txt && git commit -m "seo: update 2026 robots policy for retrieval vs training bots"`, `git status --short --branch`, `nl -ba public/robots.txt | sed -n '1,220p'`, `git rev-parse --short HEAD`) and they all completed successfully (commit `58035e4`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde1ece94c832c8b94a3ff19c71e50)